### PR TITLE
call `pyrootutils.setup_root(..., pythonpath=True)` in all new main entry scripts

### DIFF
--- a/src/utils/align_i2l_nodes.py
+++ b/src/utils/align_i2l_nodes.py
@@ -32,9 +32,11 @@ For more details on SentenceTransformers models see: https://www.sbert.net/docs/
 Note: If no nodeset id is provided, the script will compute the matches and mismatches between
 the I- and L-nodes for all nodesets in the directory.
 """
+import pyrootutils
+
+pyrootutils.setup_root(search_from=__file__, indicator=[".project-root"], pythonpath=True)
 
 import argparse
-import datetime
 import logging
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Set, Tuple

--- a/src/utils/count_statistics.py
+++ b/src/utils/count_statistics.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import pyrootutils
+
+pyrootutils.setup_root(search_from=__file__, indicator=[".project-root"], pythonpath=True)
+
 import argparse
 import io
 import json

--- a/src/utils/create_relation_nodes.py
+++ b/src/utils/create_relation_nodes.py
@@ -1,3 +1,7 @@
+import pyrootutils
+
+pyrootutils.setup_root(search_from=__file__, indicator=[".project-root"], pythonpath=True)
+
 import argparse
 import logging
 import os


### PR DESCRIPTION
This fixes the issue: `from src.utils.nodeset_utils import ModuleNotFoundError: No module named 'src'`