### PR TITLE
fix missing dymanically loaded pie classes

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -39,6 +39,8 @@ import hydra
 import pytorch_lightning as pl
 from omegaconf import DictConfig
 from pie_datasets import DatasetDict
+from pie_modules.models import *  # noqa: F403
+from pie_modules.taskmodules import *  # noqa: F403
 from pytorch_ie.core import PyTorchIEModel, TaskModule
 from pytorch_ie.models import *  # noqa: F403
 from pytorch_ie.taskmodules import *  # noqa: F403

--- a/src/predict.py
+++ b/src/predict.py
@@ -40,6 +40,8 @@ import hydra
 import pytorch_lightning as pl
 from omegaconf import DictConfig, OmegaConf
 from pie_datasets import DatasetDict
+from pie_modules.models import *  # noqa: F403
+from pie_modules.taskmodules import *  # noqa: F403
 from pytorch_ie import Pipeline
 from pytorch_ie.models import *  # noqa: F403
 from pytorch_ie.taskmodules import *  # noqa: F403


### PR DESCRIPTION
import all models and taskmodules from pie_modules in evaluate.py and predict.py