### PR TITLE
hardcode the validation split

### DIFF
--- a/configs/dataset/dialam2024_prepared.yaml
+++ b/configs/dataset/dialam2024_prepared.yaml
@@ -6,7 +6,7 @@ create_validation_split:
   _processor_: pie_datasets.DatasetDict.move_to_new_split
   source_split: train
   target_split: validation
-  # take shuffled ~10% (140 out of 1399) of the train split as the validation split
+  # take ~10% (140 out of 1399) of the shuffled train split as the validation split
   ids:
     [
       "18275",


### PR DESCRIPTION
Even with a fixed value for `dataset.create_validation_split.seed`, it looks like the validation split is different from time to time in a not transparent way (@tanikina noticed differences when switching the base model, but not when switching other hyperparameters such as the learning rate...). With this PR, we define a fixed validation split by taking ~10% of the shuffled train files (in detail, 140 out of 1399).