### PR TITLE
add option to combine the text of l- and i-nodes

### DIFF
--- a/dataset_builders/pie/dialam2024/dialam2024.py
+++ b/dataset_builders/pie/dialam2024/dialam2024.py
@@ -43,7 +43,7 @@ def convert_to_document(
     nodeset_id: str,
     text_mode: str = "l-nodes",
     text_sep: str = " ",
-    add_i_node_text: bool = True,
+    add_i_node_text: bool = False,
 ) -> SimplifiedDialAM2024Document:
 
     # 1. create document text and L-node-spans


### PR DESCRIPTION
This adds an option `add_i_node_text` to the method `convert_to_document()` in `dataset_builders/pie/dialam2024/dialam2024.py` which allows us to combine the text of both L- and I-nodes.
It is set by default to False since the evaluation with the official script (see https://github.com/ArneBinder/dialam-2024-shared-task/pull/34) resulted in slightly worse scores compared to the original version that uses only L-node texts.